### PR TITLE
Hotfix: strict mode requires vars to be defined

### DIFF
--- a/lib/mongoose-api-query.js
+++ b/lib/mongoose-api-query.js
@@ -2,9 +2,13 @@ module.exports = exports = function apiQueryPlugin (schema) {
 
   schema.statics.apiQuery = function(rawParams, cb) {
     var model = this
-      , params = model.apiQueryParams(rawParams);
-    // Create the Mongoose Query object.
-    query = model.find(params.searchParams).limit(params.per_page).skip((params.page - 1) * params.per_page)
+      , params = model.apiQueryParams(rawParams),
+
+        // Create the Mongoose Query object.
+        query = model
+          .find(params.searchParams)
+          .limit(params.per_page)
+          .skip((params.page - 1) * params.per_page);
 
     if (params.sort) query = query.sort(params.sort)
 


### PR DESCRIPTION
Working strict mode found an error in base repository [mongoose-api-query](https://github.com/ajb/mongoose-api-query) that leads me to your maintained repo.

It's a straight PR