### PR TITLE
Array and String types should be treated the same way.

### DIFF
--- a/lib/mongoose-api-query.js
+++ b/lib/mongoose-api-query.js
@@ -111,7 +111,7 @@ module.exports = exports = function apiQueryPlugin (schema) {
             addSearchParam(parseInt(val));
           }
         }
-      } else if (paramType === "String") {
+      } else if (paramType === "String" || paramType === "Array") {
         if (val.match(',')) {
           var options = val.split(',').map(function(str){
             return new RegExp(str, 'i');
@@ -153,12 +153,7 @@ module.exports = exports = function apiQueryPlugin (schema) {
         addSearchParam(distObj);
       } else if (paramType === "ObjectId") {
         addSearchParam(val);
-      } else if (paramType === "Array") {
-         addSearchParam(val);
-         console.log(lcKey )
-
       }
-
     };
 
     var parseParam = function (key, val) {


### PR DESCRIPTION
Fixes bug where search operators weren't working for Array types.