### PR TITLE
Fix bug that assumes all strings with numbers are number only values

### DIFF
--- a/lib/mongoose-api-query.js
+++ b/lib/mongoose-api-query.js
@@ -80,7 +80,7 @@ module.exports = exports = function apiQueryPlugin (schema) {
         paramType = "Number";
       } else if (schema.paths[lcKey].constructor.name === "ObjectId") {
         paramType = "ObjectId";
-      }//changed 
+      }//changed
        else if (schema.paths[lcKey].constructor.name === "SchemaArray") {
         paramType = "Array";
       }
@@ -124,7 +124,7 @@ module.exports = exports = function apiQueryPlugin (schema) {
           } else {
             addSearchParam({$in: options});
           }
-        } else if (val.match(/([0-9]+)/)) {
+        } else if (val.match(/^([0-9]+)$/)) {
           if (operator === "gt" ||
               operator === "gte" ||
               operator === "lt" ||


### PR DESCRIPTION
__Problem__:
If you pass a search value that contains a number (e.g. `hello123`) this logic assumes that the entire search value is a number because it loosely matches against `/([0-9]+)/` and attempts to perform numeric comparisons against that value (which throws errors).

__Solution__:
Tighten the regexp to `/^([0-9]+)$/` to ensure that operators like `gt`, `gte`, etc are only attempted when true numeric search values are used.